### PR TITLE
Hotfix: marklist count icon not displaying when no cookie is present

### DIFF
--- a/routes/validate.rb
+++ b/routes/validate.rb
@@ -2,12 +2,15 @@
 
 get '/:mechanism/marklist-validate' do
   raw_marklist = request.cookies['marklist']
-  raw_species = raw_marklist.split(',')
-  this_mechanism = params[:mechanism]
-  valid_species = DB[:SpeciesMechanisms]
-                  .where(Name: raw_species,
-                         Mechanism: this_mechanism)
-                  .select_map(:Name)
+  if raw_marklist.nil?
+    valid_species = []
+  else
+    raw_species = raw_marklist.split(',')
+    valid_species = DB[:SpeciesMechanisms]
+                    .where(Name: raw_species,
+                           Mechanism: params[:mechanism])
+                    .select_map(:Name)
+  end
   content_type :json
   { valid: valid_species }.to_json
 end


### PR DESCRIPTION
Fixed by adding a simple check for the existence of the cookie before trying to separate the marklist entries into constituent species.