### PR TITLE
Escape text when generating html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'aws-sdk-sns', '~> 1'
 gem 'erubi'
 gem 'public_suffix', '~> 5.0'
 gem 'puma', '>= 6.4.2'
-gem 'rack', ['~> 2.2.6', '>= 2.2.6.3']
+gem 'rack', ['~> 2.2.8', '>= 2.2.8.1']
 gem 'rest-client'
 gem 'sequel'
 gem 'sinatra', ['~> 2', '!= 2.1.0']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (2.2.8.1)
     rack-protection (2.2.4)
       rack
     rack-test (2.1.0)
@@ -239,7 +239,7 @@ DEPENDENCIES
   erubi
   public_suffix (~> 5.0)
   puma (>= 6.4.2)
-  rack (~> 2.2.6, >= 2.2.6.3)
+  rack (~> 2.2.8, >= 2.2.8.1)
   rack-test
   rest-client
   rspec

--- a/routes/reaction_category.rb
+++ b/routes/reaction_category.rb
@@ -11,7 +11,7 @@ get '/:mechanism/reaction_category' do
                fn = DB[:ReactionCategories].where(ReactionCategory: cat,
                                                   Mechanism: mechanism).get(:DocumentationFilename)
                if fn.nil?
-                 "<p>Unknown reaction category '#{cat}' for mechanism '#{mechanism}'.</p>"
+                 "<p>Unknown reaction category '#{Rack::Utils.escape_html(cat)}' for mechanism '#{mechanism}'.</p>"
                else
                  full_fn = File.join('public', 'static', mechanism, 'reaction_categories', fn)
                  File.file?(full_fn) ? File.read(full_fn) : "<p>Unable to locate static file '#{full_fn}'.</p>"


### PR DESCRIPTION
This addresses the initial problem, and I've also fixed a vulnerability found by `bundler audit` regarding an old version of rack. There is still a problem with the `nokogiri` version, but this requires updating to Ruby 3 to fix, so will be handled in a separate PR.