### PR TITLE
hotfix: prepend exports with the correct mechanism name

### DIFF
--- a/lib/mcm/export/facsimile.rb
+++ b/lib/mcm/export/facsimile.rb
@@ -5,7 +5,7 @@ module MCM
     # Exporter into Facsimile format
     class Facsimile
       CONTENT_TYPE = 'text/plain'
-      FILE_NAME = 'mcm_export.fac'
+      FILE_NAME = 'export.fac'
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/ParameterLists

--- a/lib/mcm/export/kpp.rb
+++ b/lib/mcm/export/kpp.rb
@@ -6,7 +6,7 @@ module MCM
     # rubocop:disable Metrics/ClassLength
     class KPP
       CONTENT_TYPE = 'text/plain'
-      FILE_NAME = 'mcm_export.eqn'
+      FILE_NAME = 'export.eqn'
       PHOTOLYSIS_MAPPING = {
         1 => {
           order: 1,

--- a/lib/mcm/export/species_tsv.rb
+++ b/lib/mcm/export/species_tsv.rb
@@ -5,7 +5,7 @@ module MCM
     # Exporter into TSV format
     class SpeciesTSV
       CONTENT_TYPE = 'text/csv'
-      FILE_NAME = 'mcm_export_species.tsv'
+      FILE_NAME = 'export_species.tsv'
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/ParameterLists

--- a/routes/export.rb
+++ b/routes/export.rb
@@ -42,7 +42,8 @@ get '/:mechanism/export/download' do
 
   exporter = MCM::Export::Factory.exporter_factory(params[:format])
   content_type exporter.class::CONTENT_TYPE
-  attachment exporter.class::FILE_NAME
+  filename = "#{params[:mechanism].downcase}_#{exporter.class::FILE_NAME}"
+  attachment filename
   exporter.export(
     submech_species.select(:Name),
     submech_rxns,


### PR DESCRIPTION
Closes #329 