### PR TITLE
hotfix: remove polyfill.io script

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -43,7 +43,6 @@
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
 
     <!-- MathJax with mhchem extension -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>
       window.MathJax = {


### PR DESCRIPTION
This was being used for MathJax, but given the
June 25th [attack](https://sansec.io/research/polyfill-supply-chain-attack), we will no longer use it. The benefits it provided by supporting older browsers is minimal, particularly as all MCM users are running modern browsers.