### PR TITLE
feat: Deployment on App Runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Install tools used when installing / building gems
+# Use a debian ruby image rather than the base lambda one as that expects
+# a lambda entry point
+FROM ruby:2.7-slim
+RUN apt-get update -qq && apt-get install -y build-essential libsqlite3-dev
+
+# Don't complain if bundler is run as root
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+# Try BUNDLE_DISABLE_EXEC_LOAD to true
+ENV BUNDLE_DISABLE_EXEC_LOAD=true
+ENV GEM_PATH /bundle
+ENV BUNDLE_PATH /bundle
+
+ENV APP_ROOT /var/www/docker-sinatra
+RUN mkdir -p $APP_ROOT
+WORKDIR $APP_ROOT
+ADD Gemfile* $APP_ROOT/
+RUN gem install bundler -v 2.4.22
+RUN bundle install
+ADD . $APP_ROOT
+
+EXPOSE 5000
+CMD ["bundle", "exec", "rackup", "config.ru", "-p", "5000", "-s", "puma", "-o", "0.0.0.0", "-E", "production"]


### PR DESCRIPTION
App Runner is similar to Elastic Beanstalk (EB) in that it offers a wrapper around the underlying EC2 infrastructure and can provide a one-click deployment. 
However it has some differences with EB. It is far more streamlined, abstracting away a lot of the networking side of things. This is useful if you have a relatively straightforward app (like we do).
Another big difference is that App Runner is designed first and foremost for containers, whereas in EB they are just one of the deployment options.
The final major advantage to App Runner is that it uses a pay-as-you-go pricing model. For low traffic applications such as the MCM this is a huge advantage as you are only charged when the app is in use.

I've got a test deployment through the CLI but there are some issues I'd like to confirm before migrating the production app over:

  - Is it easy to setup custom URLs with SSL? For the URL we can just change the CNAME record, but how do we attach an SSL cert?
  - Can we setup CD? It seems that App Runner is designed to be integrated with CodeRunner. Is this easy to setup? Or can we continue using GitHub Actions?
  - Can we get a CloudFormation template, or at least reference the CloudFormation stack and add in the Resource Tagging that we are required by the University?